### PR TITLE
Typo fix for Kafka Connect - create-connector

### DIFF
--- a/kafka/kafka-connect-rest.md
+++ b/kafka/kafka-connect-rest.md
@@ -18,7 +18,7 @@ Shortcuts
 ### Rest APIs
 
 | `curl /connectors` | Get list of connectors |
-| `cur -X POST -H "Content-Type: application/json" /connectors -d 'json'` | Create a connector |
+| `curl -X POST -H "Content-Type: application/json" /connectors -d 'json'` | Create a connector |
 | `curl /connectors/[name]` | Get information about a single connector |
 | `curl /connectors/[name]/config` | Get config of a single connector |
 | `curl -X PUT -H "Content-Type: application/json" /connectors/[name]/config -d 'json` | Create or update a connector config |


### PR DESCRIPTION
`curl` was missing the `l`